### PR TITLE
FIX: Ensure that the type of vals matches counts's

### DIFF
--- a/bpftools/profile_nginx_lua/profile.c
+++ b/bpftools/profile_nginx_lua/profile.c
@@ -299,7 +299,7 @@ static bool read_batch_counts_map(int fd, struct key_ext_t *items, __u32 *count)
 	void *in = NULL, *out;
 	__u32 i, n, n_read = 0;
 	int err = 0;
-	__u32 vals[*count];
+	__u64 vals[*count];
 	struct profile_key_t keys[*count];
 
 	while (n_read < *count && !err)


### PR DESCRIPTION
1. The mismatch cause incorrect val(eg. 0)
2. use `bpf_get_ns_current_pid_tgid` to get pid in docker
3. add option `stack_depth_limit`