### PR TITLE
FIX: graceful cleanup

### DIFF
--- a/bpftools/profile_nginx_lua/profile.bpf.c
+++ b/bpftools/profile_nginx_lua/profile.bpf.c
@@ -86,6 +86,10 @@ static inline int lua_get_funcdata(struct bpf_perf_event_data *ctx, cTValue *fra
 		const char *src = strdata(name);
 		if (!src)
 			return -1;
+		MSize len = BPF_PROBE_READ_USER(name, len);
+		if (!len) {
+			return -1;
+		}
 		bpf_probe_read_user_str(eventp->name, sizeof(eventp->name), src);
 		//bpf_printk("level= %d, fn_name=%s\n", level, eventp->name);
 	}
@@ -139,7 +143,7 @@ static int fix_lua_stack(struct bpf_perf_event_data *ctx, __u32 tid, int stack_i
 		if (level-- == 0)
 		{
 			level++;
-			// *size = (nextframe - frame);
+ 			// *size = (nextframe - frame);
 			/* Level found. */
 			if (lua_get_funcdata(ctx, frame, eventp, count) != 0)
 			{

--- a/bpftools/profile_nginx_lua/profile.c
+++ b/bpftools/profile_nginx_lua/profile.c
@@ -874,6 +874,10 @@ int main(int argc, char **argv)
 	if (err)
 		goto cleanup;
 
+	if (env.duration > 0) {
+		signal(SIGALRM, sig_handler);
+		alarm(env.duration);
+	}
 	signal(SIGINT, sig_handler);
 
 	if (env.pid != -1)
@@ -905,7 +909,6 @@ int main(int argc, char **argv)
 	 * We'll get sleep interrupted when someone presses Ctrl-C (which will
 	 * be "handled" with noop by sig_handler).
 	 */
-	// sleep(env.duration);
 	while (!exiting)
 	{
 		// print perf event to get stack trace


### PR DESCRIPTION
- Check `NULL` to avoid segmentfault when cleanup
- fix duration option
- fix read invalid chunkname